### PR TITLE
Fix missing comma in boilerplate/aom/defaults-PD

### DIFF
--- a/boilerplate/aom/defaults-PD.include
+++ b/boilerplate/aom/defaults-PD.include
@@ -3,7 +3,7 @@
 	"Group": "AOM",
 	"Inline Github Issues": "full",
 	"Boilerplate": "property-index no, issues-index no, copyright yes",
-	"Markup Shorthands": "css on"
+	"Markup Shorthands": "css on",
 	"Warning": "Custom",
 	"Custom Warning Title": "Warning",
 	"Custom Warning Text": "This specification is a proposed draft not endorsed by the working group."


### PR DESCRIPTION
Using the `PD` status in the metadata block of a Bikeshed .bs file currently fails with:
```
FATAL ERROR: Error loading defaults JSON:
Expecting ',' delimiter: line 7 column 2 (char 171)
Did not generate, due to fatal errors
```